### PR TITLE
Allow accessing model methods when using block anonymisers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The default strategies include:
 ### Custom strategies
 
 Anony defines some common strategies internally, but you can also write your own - they
-just need to be Ruby objects which conform to the `.call(existing_value)` signature (blocks can also be used dynamically):
+just need to be Ruby objects which conform to the `.call(existing_value)` signature:
 
 ```ruby
 module OverwriteUUID
@@ -90,8 +90,21 @@ class Manager < ApplicationRecord
 
   anonymise do
     with_strategy OverwriteUUID, :id
-    # block syntax is also supported
+  end
+end
+```
+
+You can also use a block. Blocks are executed in the context of the model so they can
+access local properties & methods, and they take the existing value of the column as the
+only argument:
+
+```ruby
+class Employee < ApplicationRecord
+  include Anony::Anonymisable
+
+  anonymise do
     with_strategy(:first_name) { |name| Digest::SHA2.hexdigest(name) }
+    with_strategy(:last_name) { "previous-name-of-#{id}" }
   end
 end
 

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -120,7 +120,12 @@ module Anony
 
       strategy = self.class.anonymisable_fields.fetch(field)
       current_value = read_attribute(field)
-      anonymised_value = strategy.call(current_value)
+
+      anonymised_value = if strategy.is_a?(Proc)
+                           instance_exec(current_value, &strategy)
+                         else
+                           strategy.call(current_value)
+                         end
 
       write_attribute(field, anonymised_value)
     end


### PR DESCRIPTION
`instance_exec` allows us to execute a block, with arguments, in the local context, allowing the block to access local behaviours (for example, your anonymisation could be conditional, or rely on another property of the model).

We don't support this for Modules/etc at this time because it would require converting the module into a proc first (via `Module.method(:call)`), which has performance and behavioural implications.

The README changes should explain a good usage example.