### PR TITLE
Add a strategy for setting a constant value

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ employee
 The default strategies include:
 
 * **nilable**, overwrites the field with `nil`
+* **with_value**, overwrites the field with a constant value
 * **hex**, overwrites the field with random hexadecimal characters
 * **email**, overwrites the field with a configured email (see
   [Configuration](#configuration))

--- a/lib/anony.rb
+++ b/lib/anony.rb
@@ -6,6 +6,7 @@ module Anony
   require_relative "anony/field_exception"
   require_relative "anony/strategies/anonymised_email"
   require_relative "anony/strategies/anonymised_phone_number"
+  require_relative "anony/strategies/constant"
   require_relative "anony/strategies/current_datetime"
   require_relative "anony/strategies/nilable"
   require_relative "anony/strategies/no_op"

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -28,6 +28,10 @@ module Anony
       fields.each { |field| anonymisable_fields[field] = strategy }
     end
 
+    def with_value(value, *fields)
+      with_strategy(Strategies::Constant.new(value), *fields)
+    end
+
     def hex(*fields, max_length: 36)
       with_strategy(Strategies::OverwriteHex.new(max_length), *fields)
     end

--- a/lib/anony/strategies/constant.rb
+++ b/lib/anony/strategies/constant.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Anony
+  module Strategies
+    Constant = Struct.new(:value) do
+      def call(_existing_value)
+        value
+      end
+    end
+  end
+end

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe Anony::Anonymisable do
       klass = Class.new do
         include Anony::Anonymisable
 
-        attr_accessor :null, :hexy, :mailo, :phone_numba, :started_at
+        attr_accessor :null, :hexy, :mailo, :phone_numba, :started_at, :konstant
 
         def self.column_names
           %w[null hexy mailo phone_numba started_at]
@@ -381,6 +381,7 @@ RSpec.describe Anony::Anonymisable do
           email :mailo
           phone_number :phone_numba
           current_datetime :started_at
+          with_value 123, :konstant
         end
 
         alias_method :read_attribute, :send
@@ -402,6 +403,7 @@ RSpec.describe Anony::Anonymisable do
       model.mailo = "baz"
       model.phone_numba = "qux"
       model.started_at = "qax"
+      model.konstant = "fax"
     end
 
     it "calls the relevant anonymisers" do
@@ -411,6 +413,8 @@ RSpec.describe Anony::Anonymisable do
       expect(Anony::Strategies::CurrentDatetime).to receive(:call).with("qax")
       expect_any_instance_of(Anony::Strategies::OverwriteHex).
         to receive(:call).with("bar")
+      expect_any_instance_of(Anony::Strategies::Constant).
+        to receive(:call).with("fax")
 
       model.anonymise!
     end

--- a/spec/anony/strategies/constant_spec.rb
+++ b/spec/anony/strategies/constant_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Anony::Strategies::Constant do
+  describe ".call" do
+    subject(:result) { described_class.new(constant).call(value) }
+
+    let(:value) { "old value" }
+    let(:constant) { "new value" }
+
+    it { is_expected.to be constant }
+  end
+end


### PR DESCRIPTION
Adds a strategy that can be used to set a field to a constant value.  For example:

```ruby
anonymise do
  with_value 123, :foo, :bar
end
```