### PR TITLE
Allow using a constant value as a strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ class Manager < ApplicationRecord
 end
 ```
 
+If your strategy doesn't respond to `.call`, then it will be used as a constant value
+whenever the field is anonymised.
+
+```ruby
+class Employee < ApplicationRecord
+  include Anony::Anonymisable
+
+  anonymise do
+    with_strategy 123, :id
+  end
+end
+
+manager = Manager.first
+ => #<Manager id=42>
+
+manager.anonymise!
+ => true
+
+manager
+ => #<Manager id=123>
+```
+
 You can also use a block. Blocks are executed in the context of the model so they can
 access local properties & methods, and they take the existing value of the column as the
 only argument:

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Anony::Anonymisable do
         attr_accessor :a_field
         attr_accessor :b_field
         attr_accessor :c_field
+        attr_accessor :d_field
         attr_accessor :ignore_one
         attr_accessor :ignore_two
 
@@ -24,6 +25,7 @@ RSpec.describe Anony::Anonymisable do
           with_strategy StubAnoynmiser, :a_field
           with_strategy(:b_field) { |v, _| v.reverse }
           with_strategy(:c_field) { some_instance_method? ? "yes" : "no" }
+          with_strategy 321, :d_field
 
           ignore :ignore_one, :ignore_two
         end
@@ -53,6 +55,7 @@ RSpec.describe Anony::Anonymisable do
       model.a_field = double
       model.b_field = "abc"
       model.c_field = double
+      model.d_field = 123
       model.ignore_one = model.ignore_two = double
     end
 
@@ -61,7 +64,8 @@ RSpec.describe Anony::Anonymisable do
         expect { model.anonymise! }.
           to change(model, :a_field).to("OVERWRITTEN DATA").
           and change(model, :b_field).to("cba").
-          and change(model, :c_field).to("yes")
+          and change(model, :c_field).to("yes").
+          and change(model, :d_field).to(321)
       end
 
       it "saves the model" do


### PR DESCRIPTION
Allows the use of a constant value as a strategy.  For example:

```
anonymise do
  with_strategy 123, :foo, :bar
end
```

This is an alternative to #15.