### PR TITLE
Extract AnonymisableConfig to Anony::DSL

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,10 +18,6 @@ RSpec/NestedGroups:
   Exclude:
     - 'spec/anony/anonymisable_spec.rb'
 
-RSpec/MultipleExpectations:
-  Exclude:
-    - 'spec/anony/anonymisable_spec.rb'
-
 RSpec/FilePath:
   Exclude:
     - 'spec/anony/cops/define_deletion_strategy_spec.rb'

--- a/lib/anony.rb
+++ b/lib/anony.rb
@@ -3,6 +3,7 @@
 module Anony
   require_relative "anony/anonymisable"
   require_relative "anony/config"
+  require_relative "anony/dsl"
   require_relative "anony/field_exception"
   require_relative "anony/strategies/anonymised_email"
   require_relative "anony/strategies/anonymised_phone_number"

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -3,70 +3,9 @@
 require "active_support/concern"
 require "active_support/core_ext/module"
 
+require_relative "dsl"
+
 module Anony
-  class AnonymisableConfig
-    def initialize
-      @anonymisable_fields = {}
-      @destroy_on_anonymise = false
-    end
-
-    attr_reader :anonymisable_fields, :destroy_on_anonymise
-
-    def with_strategy(strategy, *fields, &block)
-      if block_given?
-        fields.unshift(strategy)
-        strategy = block
-      end
-
-      fields = fields.flatten
-
-      raise ArgumentError, "Block or Strategy object required" unless strategy
-      raise ArgumentError, "One or more fields required" unless fields.any?
-      raise ArgumentError, "Can't specify destroy and strategies for fields" if destroy_on_anonymise
-
-      fields.each { |field| anonymisable_fields[field] = strategy }
-    end
-
-    def hex(*fields, max_length: 36)
-      with_strategy(Strategies::OverwriteHex.new(max_length), *fields)
-    end
-
-    def email(*fields)
-      with_strategy(Strategies::AnonymisedEmail, *fields)
-    end
-
-    def phone_number(*fields)
-      with_strategy(Strategies::AnonymisedPhoneNumber, *fields)
-    end
-
-    def nilable(*fields)
-      with_strategy(Strategies::Nilable, *fields)
-    end
-
-    def current_datetime(*fields)
-      with_strategy(Strategies::CurrentDatetime, *fields)
-    end
-
-    def ignore(*fields)
-      already_ignored = fields.select { |field| Config.ignore?(field) }
-
-      if already_ignored.any?
-        raise ArgumentError, "Cannot ignore #{already_ignored.inspect} " \
-                             "(fields already ignored in Anony::Config)"
-      end
-
-      with_strategy(Strategies::NoOp, *fields)
-    end
-
-    def destroy
-      unless anonymisable_fields.empty?
-        raise ArgumentError, "Can't specify destroy and strategies for fields"
-      end
-
-      @destroy_on_anonymise = true
-    end
-  end
-
   module Anonymisable
     extend ActiveSupport::Concern
 
@@ -74,14 +13,14 @@ module Anony
 
     class_methods do
       def anonymise(&block)
-        anonymiser.instance_eval(&block)
+        anonymise_config.instance_eval(&block)
       end
 
-      def anonymiser
-        @anonymiser ||= AnonymisableConfig.new
+      private def anonymise_config
+        @anonymise_config ||= DSL.new
       end
 
-      delegate :anonymisable_fields, :destroy_on_anonymise, to: :anonymiser
+      delegate :anonymisable_fields, :destroy_on_anonymise, to: :anonymise_config
     end
 
     def anonymise!

--- a/lib/anony/dsl.rb
+++ b/lib/anony/dsl.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Anony
+  class DSL
+    def initialize
+      @anonymisable_fields = {}
+      @destroy_on_anonymise = false
+    end
+
+    attr_reader :anonymisable_fields, :destroy_on_anonymise
+
+    def with_strategy(strategy, *fields, &block)
+      if block_given?
+        fields.unshift(strategy)
+        strategy = block
+      end
+
+      fields = fields.flatten
+
+      raise ArgumentError, "Block or Strategy object required" unless strategy
+      raise ArgumentError, "One or more fields required" unless fields.any?
+      raise ArgumentError, "Can't specify destroy and strategies for fields" if destroy_on_anonymise
+
+      fields.each { |field| anonymisable_fields[field] = strategy }
+    end
+
+    def hex(*fields, max_length: 36)
+      with_strategy(Strategies::OverwriteHex.new(max_length), *fields)
+    end
+
+    def email(*fields)
+      with_strategy(Strategies::AnonymisedEmail, *fields)
+    end
+
+    def phone_number(*fields)
+      with_strategy(Strategies::AnonymisedPhoneNumber, *fields)
+    end
+
+    def nilable(*fields)
+      with_strategy(Strategies::Nilable, *fields)
+    end
+
+    def current_datetime(*fields)
+      with_strategy(Strategies::CurrentDatetime, *fields)
+    end
+
+    def ignore(*fields)
+      already_ignored = fields.select { |field| Config.ignore?(field) }
+
+      if already_ignored.any?
+        raise ArgumentError, "Cannot ignore #{already_ignored.inspect} " \
+                             "(fields already ignored in Anony::Config)"
+      end
+
+      with_strategy(Strategies::NoOp, *fields)
+    end
+
+    def destroy
+      unless anonymisable_fields.empty?
+        raise ArgumentError, "Can't specify destroy and strategies for fields"
+      end
+
+      @destroy_on_anonymise = true
+    end
+  end
+end

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -318,67 +318,13 @@ RSpec.describe Anony::Anonymisable do
       end
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it "models do not leak configuration" do
       #  We had a case where these leaked, so we want to explicitly test it.
       expect(a_class.anonymisable_fields).to match(a_field: anything)
       expect(b_class.anonymisable_fields).to match(b_field: anything)
     end
-  end
-
-  describe "#with_strategy" do
-    let(:config) { Anony::AnonymisableConfig.new }
-
-    context "no arguments" do
-      it "throws an argumenterror" do
-        expect { config.with_strategy }.to raise_error(ArgumentError)
-      end
-    end
-
-    context "strategy without any fields" do
-      it "throws an argumenterror" do
-        expect { config.with_strategy(StubAnoynmiser) }.to raise_error(ArgumentError)
-      end
-    end
-
-    context "field without any strategy" do
-      it "throws an argumenterror" do
-        expect { config.with_strategy(:field) }.to raise_error(ArgumentError)
-      end
-    end
-
-    it "with an array of fields and no block / strategy" do
-      expect { config.with_strategy(%i[foo bar]) }.to raise_error(ArgumentError)
-    end
-
-    context "two arguments" do
-      it "registers the field to the strategy" do
-        config.with_strategy(StubAnoynmiser, :field)
-        expect(config.anonymisable_fields).to eq(field: StubAnoynmiser)
-      end
-
-      it "with a block" do
-        config.with_strategy(:foo, :bar) { |v| v }
-        expect(config.anonymisable_fields.keys).to eq(%i[foo bar])
-      end
-
-      it "with a strategy and an array of fields" do
-        config.with_strategy(StubAnoynmiser, %i[foo bar])
-        expect(config.anonymisable_fields.keys).to eq(%i[foo bar])
-        expect(config.anonymisable_fields.values).to all(eq(StubAnoynmiser))
-      end
-
-      it "with a block and an array of fields" do
-        config.with_strategy(%i[foo bar]) { |v| v }
-        expect(config.anonymisable_fields.keys).to eq(%i[foo bar])
-      end
-    end
-
-    context "a strategy for two fields" do
-      it "registers them correctly" do
-        config.with_strategy(StubAnoynmiser, :foo, :bar)
-        expect(config.anonymisable_fields).to eq(foo: StubAnoynmiser, bar: StubAnoynmiser)
-      end
-    end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 
   describe "helper methods" do
@@ -421,6 +367,7 @@ RSpec.describe Anony::Anonymisable do
       model.started_at = "qax"
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it "calls the relevant anonymisers" do
       expect(Anony::Strategies::Nilable).to receive(:call).with("foo")
       expect(Anony::Strategies::AnonymisedEmail).to receive(:call).with("baz")
@@ -431,5 +378,6 @@ RSpec.describe Anony::Anonymisable do
 
       model.anonymise!
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 end

--- a/spec/anony/dsl_spec.rb
+++ b/spec/anony/dsl_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Anony::DSL do
+  describe "#with_strategy" do
+    let(:config) { described_class.new }
+
+    context "no arguments" do
+      it "throws an argumenterror" do
+        expect { config.with_strategy }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "strategy without any fields" do
+      it "throws an argumenterror" do
+        expect { config.with_strategy(StubAnoynmiser) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "field without any strategy" do
+      it "throws an argumenterror" do
+        expect { config.with_strategy(:field) }.to raise_error(ArgumentError)
+      end
+    end
+
+    it "with an array of fields and no block / strategy" do
+      expect { config.with_strategy(%i[foo bar]) }.to raise_error(ArgumentError)
+    end
+
+    context "two arguments" do
+      it "registers the field to the strategy" do
+        config.with_strategy(StubAnoynmiser, :field)
+        expect(config.anonymisable_fields).to eq(field: StubAnoynmiser)
+      end
+
+      it "with a block" do
+        config.with_strategy(:foo, :bar) { |v| v }
+        expect(config.anonymisable_fields.keys).to eq(%i[foo bar])
+      end
+
+      it "with a strategy and an array of fields" do
+        config.with_strategy(StubAnoynmiser, %i[foo bar])
+        expect(config.anonymisable_fields).to eq(
+          foo: StubAnoynmiser,
+          bar: StubAnoynmiser,
+        )
+      end
+
+      it "with a block and an array of fields" do
+        config.with_strategy(%i[foo bar]) { |v| v }
+        expect(config.anonymisable_fields.keys).to eq(%i[foo bar])
+      end
+    end
+
+    context "a strategy for two fields" do
+      it "registers them correctly" do
+        config.with_strategy(StubAnoynmiser, :foo, :bar)
+        expect(config.anonymisable_fields).to eq(foo: StubAnoynmiser, bar: StubAnoynmiser)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using a separate class makes it easier to distinguish the options available in the `anonymise` block from the other mechanics of anonymisation.