### PR TITLE
Make valid_anonymisation? a class method

### DIFF
--- a/lib/anony/rspec_shared_examples.rb
+++ b/lib/anony/rspec_shared_examples.rb
@@ -3,7 +3,9 @@
 require "rspec"
 
 RSpec.shared_examples "anonymisable model" do
-  it { is_expected.to be_valid_anonymisation }
+  it "has a valid strategy defined" do
+    expect(subject.class).to be_valid_anonymisation
+  end
 
   it "successfully calls #anonymise!" do
     expect(subject.anonymise!).to be true
@@ -11,7 +13,9 @@ RSpec.shared_examples "anonymisable model" do
 end
 
 RSpec.shared_examples "anonymisable model with destruction" do
-  it { is_expected.to be_valid_anonymisation }
+  it "has a valid strategy defined" do
+    expect(subject.class).to be_valid_anonymisation
+  end
 
   it "destroys the model" do
     expect { subject.anonymise! }.to change(described_class, :count).by(-1)

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Anony::Anonymisable do
   end
 
   context "valid model anonymisation" do
-    let(:model) do
-      klass = Class.new do
+    let(:klass) do
+      Class.new do
         include Anony::Anonymisable
 
         attr_accessor :a_field
@@ -47,9 +47,9 @@ RSpec.describe Anony::Anonymisable do
           true
         end
       end
-
-      klass.new
     end
+
+    let(:model) { klass.new }
 
     before do
       model.a_field = double
@@ -83,15 +83,15 @@ RSpec.describe Anony::Anonymisable do
     describe "#valid_anonymisation?" do
       context "all fields are handled" do
         it "is valid" do
-          expect(model).to be_valid_anonymisation
+          expect(klass).to be_valid_anonymisation
         end
       end
     end
   end
 
   context "destroy on anonymise" do
-    let(:model) do
-      klass = Class.new do
+    let(:klass) do
+      Class.new do
         include Anony::Anonymisable
 
         attr_accessor :a_field
@@ -104,9 +104,9 @@ RSpec.describe Anony::Anonymisable do
           true
         end
       end
-
-      klass.new
     end
+
+    let(:model) { klass.new }
 
     describe "#anonymise!" do
       it "destroys the model" do
@@ -118,42 +118,50 @@ RSpec.describe Anony::Anonymisable do
 
     describe "#valid_anonymisation?" do
       it "is valid" do
-        expect(model).to be_valid_anonymisation
+        expect(klass).to be_valid_anonymisation
       end
     end
   end
 
   context "invalid model anonymisation" do
-    describe "#valid_anonymisation?" do
-      let(:model) do
-        klass = Class.new do
-          include Anony::Anonymisable
+    let(:klass) do
+      Class.new do
+        include Anony::Anonymisable
 
-          attr_accessor :a_field
-          attr_accessor :b_field
+        attr_accessor :a_field
+        attr_accessor :b_field
 
-          anonymise do
-            with_strategy StubAnoynmiser, :a_field
-          end
-
-          def self.column_names
-            %w[a_field b_field]
-          end
+        anonymise do
+          with_strategy StubAnoynmiser, :a_field
         end
 
-        klass.new
+        def self.column_names
+          %w[a_field b_field]
+        end
       end
+    end
 
+    describe "#valid_anonymisation?" do
       it "fails" do
-        expect(model).to_not be_valid_anonymisation
+        expect(klass).to_not be_valid_anonymisation
+      end
+    end
+
+    describe "anonymise!" do
+      let(:model) { klass.new }
+
+      it "throws an exception" do
+        expect { model.anonymise! }.to raise_error(
+          Anony::FieldException, "Invalid anonymisation strategy for field(s) [:b_field]"
+        )
       end
     end
   end
 
   context "no anonymise block" do
     describe "#valid_anonymisation?" do
-      let(:model) do
-        klass = Class.new do
+      let(:klass) do
+        Class.new do
           include Anony::Anonymisable
 
           attr_accessor :a_field
@@ -163,12 +171,10 @@ RSpec.describe Anony::Anonymisable do
             %w[a_field b_field]
           end
         end
-
-        klass.new
       end
 
       it "fails" do
-        expect(model).to_not be_valid_anonymisation
+        expect(klass).to_not be_valid_anonymisation
       end
     end
   end
@@ -236,7 +242,7 @@ RSpec.describe Anony::Anonymisable do
     end
 
     it "is a valid anonymisation even though column is not configured" do
-      expect(klass.new).to be_valid_anonymisation
+      expect(klass).to be_valid_anonymisation
     end
 
     it "sets anonymised_at = Time.zone.now when anonymising" do
@@ -283,7 +289,7 @@ RSpec.describe Anony::Anonymisable do
         end
       end
 
-      expect(klass.new).to be_valid_anonymisation
+      expect(klass).to be_valid_anonymisation
     end
   end
 


### PR DESCRIPTION
This method doesn't depend on any properties of the instance, so it can be a class method.

This allows us to monitor at runtime which models have valid anonymisation strategies defined, so we can emit an appropriate metric.