### PR TITLE
Only apply anonymisation strategies to columns that are defined

### DIFF
--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -57,15 +57,13 @@ module Anony
     end
 
     private def anonymise_configured_fields
-      self.class.anonymisable_fields.each_key do |field|
-        anonymise_field(field)
-      end
+      self.class.column_names.each { |field| anonymise_field(field) }
     end
 
     private def anonymise_field(field)
-      raise FieldException, field unless self.class.anonymisable_fields.key?(field)
+      strategy = self.class.anonymisable_fields[field.to_sym]
+      return unless strategy.present?
 
-      strategy = self.class.anonymisable_fields.fetch(field)
       current_value = read_attribute(field)
 
       write_attribute(field, anonymised_value(strategy, current_value))

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -27,11 +27,13 @@ RSpec.describe Anony::Anonymisable do
           with_strategy(:c_field) { some_instance_method? ? "yes" : "no" }
           with_strategy 321, :d_field
 
+          with_strategy "foo", :missing_field
+
           ignore :ignore_one, :ignore_two
         end
 
         def self.column_names
-          %w[a_field b_field c_field ignore_one ignore_two]
+          %w[a_field b_field c_field d_field ignore_one ignore_two]
         end
 
         alias_method :read_attribute, :send


### PR DESCRIPTION
Currently, anonymisation strategies have to be kept in lockstep with the database structure.  This is a problem when code deploys and database migrations happen at different times.

This commit ensures that anonymisation strategies only run for columns that are defined in the databse.  This means that anonymisation strategies can be defined and deployed before database migrations run, and they will take effect once the new column is in place.