### PR TITLE
Only apply anonymisation strategies to columns that are defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,16 @@ temporary.persisted?
 
 Note that it isn't possible to define both anonymisation rules and destruction.
 
+## Adding new columns
+
+Anony will throw an exception if you try to anonymise a model without specifying a
+strategy for all of the columns.  However, it's fine to define a strategy for a column
+that hasn't yet been added.
+
+This means that, in order to add a new column, you should first define a strategy for it,
+and deploy that code change alone.  Once that's done, you can introduce and deploy the
+migration that will add the new column.
+
 ## Configuration
 
 Anony exposes several configuration options on the `Anony::Config` singleton. We

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -64,6 +64,7 @@ module Anony
 
     private def anonymise_field(field)
       raise FieldException, field unless self.class.anonymisable_fields.key?(field)
+      return unless self.class.column_names.include?(field.to_s)
 
       strategy = self.class.anonymisable_fields.fetch(field)
       current_value = read_attribute(field)

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -27,11 +27,13 @@ RSpec.describe Anony::Anonymisable do
           with_strategy(:c_field) { some_instance_method? ? "yes" : "no" }
           with_strategy 321, :d_field
 
+          with_strategy "foo", :missing_field
+
           ignore :ignore_one, :ignore_two
         end
 
         def self.column_names
-          %w[a_field b_field c_field ignore_one ignore_two]
+          %w[a_field b_field c_field d_field ignore_one ignore_two]
         end
 
         alias_method :read_attribute, :send


### PR DESCRIPTION
Currently, anonymisation strategies have to be kept in lockstep with the database structure.  This is a problem when code deploys and database migrations happen at different times.

This commit ensures that anonymisation strategies only run for columns that are defined in the databse.  This means that anonymisation strategies can be defined and deployed before database migrations run, and they will take effect once the new column is in place.

Replaces #27.