### PR TITLE
Prevent multiple strategies on a field

### DIFF
--- a/lib/anony.rb
+++ b/lib/anony.rb
@@ -5,6 +5,7 @@ module Anony
   require_relative "anony/config"
   require_relative "anony/dsl"
   require_relative "anony/field_exception"
+  require_relative "anony/overwritten_strategy_exception"
   require_relative "anony/strategies"
   require_relative "anony/strategies/anonymised_email"
   require_relative "anony/strategies/anonymised_phone_number"

--- a/lib/anony/dsl.rb
+++ b/lib/anony/dsl.rb
@@ -61,6 +61,8 @@ module Anony
       raise ArgumentError, "One or more fields required" unless fields.any?
       raise ArgumentError, "Can't specify destroy and strategies for fields" if destroy_on_anonymise
 
+      guard_overwritten_strategies!(fields)
+
       fields.each { |field| anonymisable_fields[field] = strategy }
     end
 
@@ -107,6 +109,13 @@ module Anony
       end
 
       @destroy_on_anonymise = true
+    end
+
+    private def guard_overwritten_strategies!(fields)
+      defined_fields = anonymisable_fields.keys
+      overwritten_fields = defined_fields & fields
+
+      raise OverwrittenStrategyException, overwritten_fields if overwritten_fields.any?
     end
   end
 end

--- a/lib/anony/overwritten_strategy_exception.rb
+++ b/lib/anony/overwritten_strategy_exception.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Anony
+  class OverwrittenStrategyException < StandardError
+    def initialize(fields)
+      fields = Array(fields)
+      super("Overwritten anonymisation strategy for field(s) #{fields}")
+    end
+  end
+end

--- a/spec/anony/dsl_spec.rb
+++ b/spec/anony/dsl_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe Anony::DSL do
       end
     end
 
+    context "defining a strategy on a field which already has one defined" do
+      before do
+        config.with_strategy(StubAnoynmiser, :field)
+      end
+
+      it "throws an overwritten_strategy_exception" do
+        expect { config.with_strategy(Anony::Strategies::NoOp, :field) }.
+          to raise_error(Anony::OverwrittenStrategyException)
+      end
+    end
+
     it "with an array of fields and no block / strategy" do
       expect { config.with_strategy(%i[foo bar]) }.to raise_error(ArgumentError)
     end


### PR DESCRIPTION
Its possible currently to define an anony config with multiple
strategies for a field, however the last strategy is the one used. This
can be problematic if this is the NoOp strategy.

For example

```ruby
anonmise do
  nilable :foo
  ignore :foo
end
```

Would result in a No-op. This PR introduces an error when this occurs.