### PR TITLE
Use ActiveRecord::Persistence#current_time_from_proper_timezone

### DIFF
--- a/anony.gemspec
+++ b/anony.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard", "~> 0.9.20"
 
   # For integration testing
-  spec.add_development_dependency "activerecord", "~> 6.0.1"
   spec.add_development_dependency "sqlite3", "~> 1.4.1"
 
+  spec.add_dependency "activerecord"
   spec.add_dependency "activesupport"
 end

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -96,7 +96,7 @@ module Anony
       anonymise_configured_fields
 
       if self.class.column_names.include?(ANONYMISED_AT.to_s)
-        write_attribute(ANONYMISED_AT, Strategies[:current_datetime].call)
+        write_attribute(ANONYMISED_AT, current_time_from_proper_timezone)
       end
 
       save!

--- a/lib/anony/strategies/current_datetime.rb
+++ b/lib/anony/strategies/current_datetime.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/time/zones"
-
 Anony::Strategies.register(:current_datetime) do |_original|
-  tz = Time.zone
-  raise ArgumentError, "Ensure Rails' config.time_zone is set" unless tz
-
-  tz.now
+  current_time_from_proper_timezone
 end

--- a/spec/anony/activerecord_spec.rb
+++ b/spec/anony/activerecord_spec.rb
@@ -37,12 +37,12 @@ RSpec.context "ActiveRecord integration" do
       and change(instance, :email_address).to(/[\h\-]@example.com/).
       and change(instance, :phone_number).to("+1 617 555 1294").
       and change(instance, :company_name).to("anonymised-Microsoft").
-      and change(instance, :onboarded_at).to be_within(1).of(Time.zone.now)
+      and change(instance, :onboarded_at).to be_within(1).of(Time.now)
   end
   # rubocop:enable RSpec/ExampleLength
 
   it "sets the anonymised_at column" do
     expect { instance.anonymise! }.
-      to change(instance, :anonymised_at).from(nil).to be_within(1).of(Time.zone.now)
+      to change(instance, :anonymised_at).from(nil).to be_within(1).of(Time.now)
   end
 end

--- a/spec/anony/strategies/current_datetime_spec.rb
+++ b/spec/anony/strategies/current_datetime_spec.rb
@@ -3,18 +3,21 @@
 require "spec_helper"
 
 RSpec.describe "current_datetime strategy" do # rubocop:disable RSpec/DescribeClass
-  subject(:result) { Anony::Strategies[:current_datetime].call(value) }
+  subject(:result) do
+    model.instance_exec(&Anony::Strategies[:current_datetime])
+  end
+
+  let(:klass) do
+    Class.new(ActiveRecord::Base) do
+      include Anony::Anonymisable
+
+      self.table_name = :employees
+    end
+  end
+
+  let(:model) { klass.new }
 
   let(:value) { "old value" }
 
-  it { is_expected.to be_within(1).of(Time.zone.now) }
-
-  context "when Rails timezone is not set" do
-    before { allow(Time).to receive(:zone).and_return(nil) }
-
-    it "raises an error" do
-      expect { result }.
-        to raise_error(ArgumentError, "Ensure Rails' config.time_zone is set")
-    end
-  end
+  it { is_expected.to be_within(1).of(Time.now) }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,3 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
-
-# To support :current_time strategy
-Time.zone = "UTC"


### PR DESCRIPTION
This method is used internally by the `#touch` interface, and uses some intelligent delegation to figure out which `TimeZone` to set. This also means that you shouldn't need to configure `Time.zone` before anonymising any model (only if you want to use that particular strategy).

Why would we not also update the current_datetime strategy? Well, it has a dependency on ActiveRecord, whereas the gem strictly only requires ActiveSupport. If you aren't using AR, you aren't using `anonymised_at` and therefore you don't need to define this internal method.