### PR TITLE
Fix Rubocop warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,5 +5,5 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 2.5
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100


### PR DESCRIPTION
```
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
```