### PR TITLE
Add compatibility policy and tests for Rails versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,28 +30,57 @@ references:
     - run: bundle exec rubocop --parallel --extra-details --display-style-guide
 
 jobs:
-  ruby24:
+  ruby24-rails52:
     docker:
       - image: ruby:2.4
+        environment:
+          - RAILS_VERSION=5.2
     steps: *steps
-  ruby25:
+  ruby25-rails52:
     docker:
       - image: ruby:2.5
+        environment:
+          - RAILS_VERSION=5.2
     steps: *steps
-  ruby26:
+  ruby25-rails60:
+    docker:
+      - image: ruby:2.5
+        environment:
+          - RAILS_VERSION=6.0
+    steps: *steps
+  ruby26-rails52:
     docker:
       - image: ruby:2.6
+        environment:
+          - RAILS_VERSION=5.2
     steps: *steps
-  ruby27:
+  ruby26-rails60:
+    docker:
+      - image: ruby:2.6
+        environment:
+          - RAILS_VERSION=6.0
+    steps: *steps
+  ruby27-rails52:
     docker:
       - image: ruby:2.7
+        environment:
+          - RAILS_VERSION=5.2
+    steps: *steps
+  ruby27-rails60:
+    docker:
+      - image: ruby:2.7
+        environment:
+          - RAILS_VERSION=6.0
     steps: *steps
 
 workflows:
   version: 2
   tests:
     jobs:
-      - ruby24
-      - ruby25
-      - ruby26
-      - ruby27
+      - ruby24-rails52
+      - ruby25-rails52
+      - ruby25-rails60
+      - ruby26-rails52
+      - ruby26-rails60
+      - ruby27-rails52
+      - ruby27-rails60

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in anony.gemspec
 gemspec
+
+gem "activerecord", "~> #{ENV['RAILS_VERSION']}" if ENV["RAILS_VERSION"]
+gem "activesupport", "~> #{ENV['RAILS_VERSION']}" if ENV["RAILS_VERSION"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ irb(main):002:0> user.anonymise!
  => #<Anony::Result status="overwritten" fields=[:first_name] error=nil>
 ```
 
-For our policy on compatibility with Ruby versions, see [COMPATIBILITY.md](docs/COMPATIBILITY.md).
+For our policy on compatibility with Ruby and Rails versions, see [COMPATIBILITY.md](docs/COMPATIBILITY.md).
 
 ## Installation & configuration
 

--- a/anony.gemspec
+++ b/anony.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   # For integration testing
   spec.add_development_dependency "sqlite3", "~> 1.4.1"
 
-  spec.add_dependency "activerecord"
-  spec.add_dependency "activesupport"
+  spec.add_dependency "activerecord", ">= 5.2", "< 6.1"
+  spec.add_dependency "activesupport", ">= 5.2", "< 6.1"
 end

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,17 +1,17 @@
 # Compatibility
 
-Our goal as Anony maintainers is for the library to be compatible with all supported versions of Ruby.
+Our goal as Anony maintainers is for the library to be compatible with all supported versions of Ruby and Rails.
 
-Specifically, any CRuby/MRI version that has not received an End of Life notice ([e.g. this notice for Ruby 2.1](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/)) is supported.
+Specifically, any CRuby/MRI version that has not received an End of Life notice ([e.g. this notice for Ruby 2.1](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/)) is supported. Similarly, any version of Rails listed as currently supported on [this page](http://guides.rubyonrails.org/maintenance_policy.html) is one we aim to support in Anony.
 
 To that end, [our build matrix](../.circleci/config.yml) includes all these versions.
 
-Any time Anony doesn't work on a supported version of Ruby, it's a bug, and can be reported [here](https://github.com/gocardless/anony/issues).
+Any time Anony doesn't work on a supported combination of Ruby and Rails, it's a bug, and can be reported [here](https://github.com/gocardless/Anony/issues).
 
 # Deprecation
 
-Whenever a version of Ruby falls out of support, we will mirror that change in Anony by updating the build matrix and releasing a new major version.
+Whenever a version of Ruby or Rails falls out of support, we will mirror that change in Anony by updating the build matrix and releasing a new major version.
 
 At that point, we will close any issues that only affect the unsupported version, and may choose to remove any workarounds from the code that are only necessary for the unsupported version.
 
-We will then bump the major version of Anony, to indicate the break in compatibility. Even if the new version of Anony happens to work on the unsupported version of Ruby, we consider compatibility to be broken at this point.
+We will then bump the major version of Anony, to indicate the break in compatibility. Even if the new version of Anony happens to work on the unsupported version of Ruby or Rails, we consider compatibility to be broken at this point.


### PR DESCRIPTION
Currently supported Rails versions are 5.2 and 6.0 (per https://guides.rubyonrails.org/maintenance_policy.html).  This PR tests on those versions, and updates our compatibility policy accordingly.