### PR TITLE
Throw a more useful exception when calling .anonymise without config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.1
+
+* Throw a more useful exception when calling .anonymise without config [#53](https://github.com/gocardless/anony/pull/53)
+
 # v1.0.0
 
 * Create a result object when calling `anonymise!` [#44](https://github.com/gocardless/anony/pull/44)

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -64,7 +64,9 @@ module Anony
     #   manager = Manager.first
     #   manager.anonymise!
     def anonymise!
-      raise ArgumentError, ".anonymise not yet invoked" unless self.class.anonymise_config
+      unless self.class.anonymise_config
+        raise ArgumentError, "#{self.class.name} does not have an Anony configuration"
+      end
 
       self.class.anonymise_config.validate!
       self.class.anonymise_config.apply(self)

--- a/lib/anony/version.rb
+++ b/lib/anony/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Anony
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -176,6 +176,26 @@ RSpec.describe Anony::Anonymisable do
     end
   end
 
+  context "without configuring Anony at all" do
+    let(:klass) do
+      MyUnicornModel = Class.new(ActiveRecord::Base) do
+        include Anony::Anonymisable
+
+        self.table_name = :only_ids
+      end
+    end
+
+    let(:model) { klass.new }
+
+    describe "#anonymise!" do
+      it "throws an exception" do
+        expect { model.anonymise! }.to raise_error(
+          ArgumentError, "MyUnicornModel does not have an Anony configuration"
+        )
+      end
+    end
+  end
+
   context "no anonymise block" do
     describe "#valid_anonymisation?" do
       let(:klass) do


### PR DESCRIPTION
When debugging, it's useful to know where we forgot to call `Model.anonymise` in advance (e.g. when looping through a series of models).

This PR improves that warning message to make it easier to resolve.