### PR TITLE
CircleCI: publish gem to RubyGems on version tag.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,44 @@ jobs:
 
       - run: bundle exec rubocop --parallel --extra-details --display-style-guide
 
+  publish:
+    parameters:
+      ruby-version:
+        type: string
+
+    docker:
+      - image: ruby:<<parameters.ruby-version>>
+
+    steps:
+      - checkout
+      - run:
+          name: Check gem version
+          command: |
+            ANONY_VERSION=$(ruby -r ./lib/anony/version.rb -e "puts Anony::VERSION")
+            GIT_TAG=$(git describe --tags)
+            [ "${GIT_TAG}" == v"${ANONY_VERSION}" ] && exit 0
+            echo "Failed version check (git:${GIT_TAG} gem:${ANONY_VERSION})"
+            exit 1
+      - run:
+          name: Create credentials file
+          command: |
+            mkdir -p $HOME/.gem
+            touch $HOME/.gem/credentials
+            chmod 0600 $HOME/.gem/credentials
+      - run:
+          name: Setup credentials
+          command: |
+            printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+      - run:
+          name: Gem build
+          command: gem build anony.gemspec -o anony-release.gem
+      - run:
+          name: Gem publish
+          command: gem push anony-release.gem
+
 workflows:
   version: 2
-  tests:
+  test-and-publish:
     jobs:
       - test:
           matrix:
@@ -52,3 +87,12 @@ workflows:
             exclude:
               - ruby-version: "2.4"
                 rails-version: "6.0"
+      - publish:
+          ruby-version: "2.7"
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+            branches:
+              ignore: /.*/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,35 @@
+# Releasing
+To cut a new release of Anony follow these steps:
+
+1. Create a new branch for the release.
+```sh
+git checkout master
+git pull origin master
+git checkout -b v{VERSION}
+```
+
+2. Update the version of the library in `lib/anony/version.rb` following the
+   semantic versioning guidelines.
+
+3. Update the CHANGELOG.md file with the list of changes made since the last
+   release, including the version for the current changes. Please note that the
+   version must start with the character `v` in order to match the git tag that
+   will be pushed in a later step.
+
+4. Create a pull request for this release to merge the version branch into
+   master.
+
+5. Once the pull request is approved and merged, change branch to master and
+   pull the changes.
+```sh
+git checkout master
+git pull origin master
+```
+
+6. Create a tag for the version and push. Please note that the version tag must
+   start with the character `v`. The automated release process in CircleCI will
+   take over from here.
+```sh
+git tag v{VERSION}
+git push --tags
+```


### PR DESCRIPTION
Here we add a CI job which runs only when a commit is tagged with a
version release format (e.g. vX.Y.Z). CircleCI will automatically build
and publish the artifact to RubyGems.