### PR TITLE
Introduce custom error to wrap validation errors

### DIFF
--- a/lib/anony.rb
+++ b/lib/anony.rb
@@ -3,6 +3,7 @@
 module Anony
   require_relative "anony/anonymisable"
   require_relative "anony/config"
+  require_relative "anony/errors"
   require_relative "anony/duplicate_strategy_exception"
   require_relative "anony/field_exception"
   require_relative "anony/field_level_strategies"

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -70,6 +70,8 @@ module Anony
 
       self.class.anonymise_config.validate!
       self.class.anonymise_config.apply(self)
+    rescue ActiveRecord::RecordInvalid => e
+      raise Anony::RecordInvalid, "#{self.class.name} - raised #{e.class.name} #{e.message}"
     rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotDestroyed => e
       Result.failed(e)
     end

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -63,6 +63,7 @@ module Anony
     # @example
     #   manager = Manager.first
     #   manager.anonymise!
+    # rubocop:disable Metrics/AbcSize
     def anonymise!
       unless self.class.anonymise_config
         raise ArgumentError, "#{self.class.name} does not have an Anony configuration"
@@ -75,6 +76,7 @@ module Anony
     rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotDestroyed => e
       Result.failed(e)
     end
+    # rubocop:enable Metrics/AbcSize
 
     # @!visibility private
     def self.included(base)

--- a/lib/anony/errors.rb
+++ b/lib/anony/errors.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Anony
+  class RecordInvalid < StandardError; end
+end

--- a/spec/anony/activerecord_validation_spec.rb
+++ b/spec/anony/activerecord_validation_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "anony/rspec_shared_examples"
+require_relative "helpers/database"
+
+RSpec.context "ActiveRecord integration" do
+  context "when the model has failing validation" do
+    subject(:instance) do
+      klass.create(first_name: "William", last_name: "Gates", company_name: "Microsoft")
+    end
+
+    let(:klass) do
+      Class.new(ActiveRecord::Base) do
+        include Anony::Anonymisable
+        include ActiveModel::Validations
+
+        def self.model_name
+          ActiveModel::Name.new(self, nil, "temp")
+        end
+
+        def self.name
+          "TestClass"
+        end
+
+        self.table_name = :employees
+
+        validates :email_address, presence: true
+
+        anonymise do
+          overwrite do
+            ignore :id
+            ignore :email_address
+            hex :first_name
+            nilable :last_name
+            phone_number :phone_number
+            current_datetime :onboarded_at
+            with_strategy(:company_name) { |old| "anonymised-#{old}" }
+          end
+        end
+      end
+    end
+
+    it "raises a specific error" do
+      expect { instance.anonymise! }.
+        to raise_error(
+          Anony::RecordInvalid,
+          "TestClass - raised ActiveRecord::RecordInvalid Validation failed: "\
+          "Email address can't be blank",
+        )
+    end
+  end
+end

--- a/spec/anony/activerecord_validation_spec.rb
+++ b/spec/anony/activerecord_validation_spec.rb
@@ -41,6 +41,7 @@ RSpec.context "ActiveRecord integration" do
       end
     end
 
+    # rubocop:disable RSpec/ExampleLength
     it "raises a specific error" do
       expect { instance.anonymise! }.
         to raise_error(
@@ -49,5 +50,6 @@ RSpec.context "ActiveRecord integration" do
           "Email address can't be blank",
         )
     end
+    # rubocop:enable RSpec/ExampleLength
   end
 end


### PR DESCRIPTION
Currently we can't see which model caused the validation error, this PR
changes the error raised to include the model name in the message.

Context
https://gocardless.slack.com/archives/CQ8JHSMED/p1603469668002900?thread_ts=1603384688.000100&cid=CQ8JHSMED