### PR TITLE
Disable validation on overwrite and clean up ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby-version: ["2.4", "2.5", "2.6", "2.7"]
+              ruby-version: ["2.5", "2.6", "2.7"]
               rails-version: ["5.2", "6.0", "6.1"]
-            exclude:
-              - ruby-version: "2.4"
-                rails-version: "6.0"
-              - ruby-version: "2.4"
-                rails-version: "6.1"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_gem:
   gc_ruboconfig: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Layout/LineLength:
   Max: 100

--- a/anony.gemspec
+++ b/anony.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.5"
 
   spec.add_development_dependency "bundler", "~> 2.2.0"
   spec.add_development_dependency "gc_ruboconfig", "~> 2.24.0"

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -297,12 +297,10 @@ RSpec.describe Anony::Anonymisable do
 
   context "with ignored fields in Anony::Config" do
     around do |example|
-      begin
-        original_ignores = Anony::Config.ignores
-        example.call
-      ensure
-        Anony::Config.ignores = original_ignores
-      end
+      original_ignores = Anony::Config.ignores
+      example.call
+    ensure
+      Anony::Config.ignores = original_ignores
     end
 
     before { Anony::Config.ignore_fields(:id) }

--- a/spec/anony/config_spec.rb
+++ b/spec/anony/config_spec.rb
@@ -4,12 +4,10 @@ require "spec_helper"
 
 RSpec.describe Anony::Config do
   around do |example|
-    begin
-      original_ignores = described_class.ignores
-      example.call
-    ensure
-      described_class.ignores = original_ignores
-    end
+    original_ignores = described_class.ignores
+    example.call
+  ensure
+    described_class.ignores = original_ignores
   end
 
   describe ".ignore?" do

--- a/spec/anony/field_level_strategies_spec.rb
+++ b/spec/anony/field_level_strategies_spec.rb
@@ -7,11 +7,9 @@ RSpec.describe Anony::FieldLevelStrategies do
     let(:name) { :reverse }
 
     after do
-      begin
-        described_class.undef_method(name)
-      rescue StandardError
-        nil
-      end
+      described_class.undef_method(name)
+    rescue StandardError
+      nil
     end
 
     context "with a block" do


### PR DESCRIPTION
When we run anonymisation, all we care about is for the data to be anonymised. This PR is to make sure that when overwriting, we do not run validations.