### PR TITLE
Introduce helpers (selectors) for anonymise all a subject's records.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,13 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 3.0
+  NewCops: enable
 
 Layout/LineLength:
   Max: 100
 
 Gemspec/RequiredRubyVersion:
+  Enabled: false
+
+RSpec/MultipleExpectations:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -243,6 +243,42 @@ irb(main):003:0> manager
  => #<Manager first_name="e9ab2800-d4b9-4227-94a7-7f81118d8a8a" last_name="previous-name-of-42">
 ```
 
+### Anonymising many records, or anonymising by subject
+
+**Note**: This is an experimental feature and has not been tested widely
+in production environments.
+
+You can use selectors to anonymise multiple records. You first define a block for
+a specific subject that returns a list of anonymisable records.
+
+```ruby
+anonymise do
+  selectors do
+    for_subject(:user_id) { |user_id| find_all_users(user_id) }
+  end
+end
+```
+
+You can also use `scopes`, `where`, etc when defining your selectors:
+
+```ruby
+anonymise do
+  selectors do
+    for_subject(:user_id) { |user_id| where(user_id: user_id) }
+  end
+end
+```
+
+This can then be used to anonymise all those subject using this API:
+
+```ruby
+ModelName.anonymise_for!(:user_id, "user_1234")
+```
+
+If you attempt to anonymise records with a selector that has not been defined it
+will throw an error.
+
+
 ### Identifying anonymised records
 
 If your model has an `anonymised_at` column, Anony will automatically set that value
@@ -279,6 +315,12 @@ Records can then be filtered out like so:
 class Employees < ApplicationRecord
   scope :without_anonymised, -> { where(anonymised_at: nil) }
 end
+```
+
+There is also a helper defined when `Anony::Anonymisable" is included:
+
+```ruby
+Employees.anonymised?
 ```
 
 ### Preventing anonymisation
@@ -364,6 +406,7 @@ Anony::Config.ignore_fields(:id, :created_at, :updated_at)
 
 By default, `Config.ignore_fields` is an empty array and all fields are considered
 anonymisable.
+
 
 ## Testing
 

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -54,6 +54,23 @@ module Anony
         @anonymise_config.valid?
       end
 
+      # Finds the records that relate to a particular subject and runs anonymise on
+      # each of them. If a selector is not defined it will raise an exception.
+      def anonymise_for!(subject, subject_id)
+        anonymise_config.
+          select(subject, subject_id, &:anonymise!)
+      end
+
+      # Checks if a selector has been defined for a given subject.
+      # This is useful for when writing tests to check all models have a valid selector
+      # for a given subject.
+      # @return [Boolean]
+      # @example
+      #   Manager.selector_for?(:user_id)
+      def selector_for?(subject)
+        anonymise_config.selector_for?(subject)
+      end
+
       attr_reader :anonymise_config
     end
 
@@ -72,6 +89,10 @@ module Anony
       self.class.anonymise_config.apply(self)
     rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotDestroyed => e
       Result.failed(e)
+    end
+
+    def anonymised?
+      anonymised_at.present?
     end
 
     # @!visibility private

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/module/delegation"
 
+require_relative "./not_anonymisable_exception"
 require_relative "./strategies/overwrite"
 require_relative "model_config"
 
@@ -57,8 +58,15 @@ module Anony
       # Finds the records that relate to a particular subject and runs anonymise on
       # each of them. If a selector is not defined it will raise an exception.
       def anonymise_for!(subject, subject_id)
-        anonymise_config.
-          select(subject, subject_id, &:anonymise!)
+        records = anonymise_config.
+          select(subject, subject_id)
+        records.map do |record|
+          if !record.respond_to?(:anonymise!)
+            raise NotAnonymisableException, record
+          end
+
+          record.anonymise!
+        end
       end
 
       # Checks if a selector has been defined for a given subject.

--- a/lib/anony/model_config.rb
+++ b/lib/anony/model_config.rb
@@ -47,6 +47,7 @@ module Anony
     end
 
     delegate :valid?, :validate!, to: :@strategy
+    delegate :select, to: :@selectors_config
 
     # Use the deletion strategy instead of anonymising individual fields. This method is
     # incompatible with the fields strategy.
@@ -104,10 +105,6 @@ module Anony
     #   ModelName.anonymise_for!(:user_id, "user_1234")
     def selectors(&block)
       @selectors_config = Selectors.new(@model_class, &block)
-    end
-
-    def select(subject, subject_id, &block)
-      @selectors_config.select(subject, subject_id, &block)
     end
 
     def selector_for?(subject)

--- a/lib/anony/not_anonymisable_exception.rb
+++ b/lib/anony/not_anonymisable_exception.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Anony
+  class NotAnonymisableException < StandardError
+    def initialize(record)
+      @record = record
+      super("Record does not implement anonymise!.
+            Have you included Anony::Anonymisable and a config?")
+    end
+  end
+end

--- a/lib/anony/selector_not_found_exception.rb
+++ b/lib/anony/selector_not_found_exception.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Anony
+  class SelectorNotFoundException < StandardError
+    def initialize(selector, model_name)
+      super("Selector for #{selector} not found. Make sure you have one defined in #{model_name}")
+    end
+  end
+end

--- a/lib/anony/selectors.rb
+++ b/lib/anony/selectors.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "./selector_not_found_exception"
+
+module Anony
+  class Selectors
+    def initialize(model_class, &block)
+      @model_class = model_class
+      @selectors = {}
+      instance_exec(&block) if block
+    end
+
+    attr_reader :selectors
+
+    def for_subject(subject, &block)
+      selectors[subject] = block
+    end
+
+    def select(subject, subject_id, &block)
+      selector = selectors[subject]
+      raise SelectorNotFoundException.new(subject.to_s, @model_class.name) if selector.nil?
+
+      matching = @model_class.instance_exec(subject_id, &selector)
+      matching.map(&block)
+    end
+  end
+end

--- a/lib/anony/selectors.rb
+++ b/lib/anony/selectors.rb
@@ -16,12 +16,11 @@ module Anony
       selectors[subject] = block
     end
 
-    def select(subject, subject_id, &block)
+    def select(subject, subject_id)
       selector = selectors[subject]
       raise SelectorNotFoundException.new(subject.to_s, @model_class.name) if selector.nil?
 
-      matching = @model_class.instance_exec(subject_id, &selector)
-      matching.map(&block)
+      @model_class.instance_exec(subject_id, &selector)
     end
   end
 end

--- a/spec/anony/activerecord_spec.rb
+++ b/spec/anony/activerecord_spec.rb
@@ -34,9 +34,9 @@ RSpec.context "ActiveRecord integration" do
   # rubocop:disable RSpec/ExampleLength
   it "applies the correct changes to each column" do
     expect { instance.anonymise! }.
-      to change(instance, :first_name).to(/[\h\-]{36}/).
+      to change(instance, :first_name).to(/[\h-]{36}/).
       and change(instance, :last_name).to(nil).
-      and change(instance, :email_address).to(/[\h\-]@example.com/).
+      and change(instance, :email_address).to(/[\h-]@example.com/).
       and change(instance, :phone_number).to("+1 617 555 1294").
       and change(instance, :company_name).to("anonymised-Microsoft").
       and change(instance, :onboarded_at).to be_within(1).of(Time.now)

--- a/spec/anony/field_level_strategies_spec.rb
+++ b/spec/anony/field_level_strategies_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Anony::FieldLevelStrategies do
 
     let(:value) { "old value" }
 
-    it { is_expected.to match(/^[0-9a-f\-]+@example.com$/) }
+    it { is_expected.to match(/^[0-9a-f-]+@example.com$/) }
   end
 
   describe ":phone_number strategy" do


### PR DESCRIPTION
These can be used to anonymise all records that relate to a specific
subject.

You first define a block for a specific subject that returns a list of
anonymisable records.

```ruby
anonymise do
  selectors do
    for_subject(:user_id) { |user_id| find_all_users(user_id) }
  end
end
```

You can also use scopes, `where`, etc when defining your selectors:

```ruby
anonymise do
  selectors do
    for_subject(:user_id) { |user_id| where(user_id: "user_id") }
  end
end
```

This can then be used to anonymise all those subject using this API:

```ruby
ModelName.anonymise_for!(:user_id, "user_1234")
```

If you attempt to anonymise records with a selector that has not been defined it will throw an error.