### PR TITLE
Add Ruby 3.2, 3.3 and Rails 7.1 to GH actions matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,25 @@ jobs:
       - name: Run rubocop
         run: bundle exec rubocop --parallel --extra-details --display-style-guide
 
+  # Exclusions based on table at https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
   tests:
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7, 3.0, 3.1]
-        rails-version: [6.0, 6.1, 7.0]
+        ruby-version: [2.6, 2.7, 3.0, 3.1, 3.2, 3.3]
+        rails-version: [6.0, 6.1, 7.0, 7.1]
         exclude:
           - ruby-version: 2.6
             rails-version: 7.0
+          - ruby-version: 2.6
+            rails-version: 7.1
+          - ruby-version: 3.0
+            rails-version: 6.0
+          - ruby-version: 3.1
+            rails-version: 6.0
+          - ruby-version: 3.2
+            rails-version: 6.0
+          - ruby-version: 3.3
+            rails-version: 6.0
     runs-on: ubuntu-latest
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.0.0
+
+- Add support for Ruby 3.2, 3.3 and Rails 7.1
+
 # v1.2.0
 
 - Add support for configuring multiple superclasses for the `DefineDeletionStrategy` cop [#98](https://github.com/gocardless/anony/pull/98)

--- a/lib/anony/version.rb
+++ b/lib/anony/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Anony
-  VERSION = "1.2.0"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
Effectively add support for these versions by ensuring that they work correctly enough to pass the tests. After merging this, the required checks need updating to include the new versions and drop EOL versions which can then be removed in a subsequent PR