### PR TITLE
Drop Ruby 2.6, 2.7 and Rails 6.0 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,21 +19,8 @@ jobs:
   tests:
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7, 3.0, 3.1, 3.2, 3.3]
-        rails-version: [6.0, 6.1, 7.0, 7.1]
-        exclude:
-          - ruby-version: 2.6
-            rails-version: 7.0
-          - ruby-version: 2.6
-            rails-version: 7.1
-          - ruby-version: 3.0
-            rails-version: 6.0
-          - ruby-version: 3.1
-            rails-version: 6.0
-          - ruby-version: 3.2
-            rails-version: 6.0
-          - ruby-version: 3.3
-            rails-version: 6.0
+        ruby-version: [3.0, 3.1, 3.2, 3.3]
+        rails-version: [6.1, 7.0, 7.1]
     runs-on: ubuntu-latest
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v2.0.0
 
 - Add support for Ruby 3.2, 3.3 and Rails 7.1
+- Drop support for EOL Ruby 2.6, 2.7 and Rails 6.0
 
 # v1.2.0
 

--- a/anony.gemspec
+++ b/anony.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "gc_ruboconfig", "~> 3.6.0"


### PR DESCRIPTION
These are all now EOL