### PR TITLE
Add `for_associations` selector for anonymising related records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.4.0
+
+- Add `for_association` selector for anonymising related models
+
 # v1.3.0
 
 - Add support for Ruby 3.2, 3.3 and Rails 7.1

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -94,7 +94,18 @@ module Anony
       end
 
       self.class.anonymise_config.validate!
-      self.class.anonymise_config.apply(self)
+      result = self.class.anonymise_config.apply(self)
+
+      if self.class.anonymise_config.associations
+        [
+          result,
+          *self.class.anonymise_config.associations&.flat_map do |association|
+            send(association).map(&:anonymise!)
+          end,
+        ]
+      else
+        result
+      end
     rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotDestroyed => e
       Result.failed(e)
     end

--- a/lib/anony/model_config.rb
+++ b/lib/anony/model_config.rb
@@ -48,6 +48,7 @@ module Anony
 
     delegate :valid?, :validate!, to: :@strategy
     delegate :select, to: :@selectors_config
+    delegate :associations, to: :@selectors_config, allow_nil: true
 
     # Use the deletion strategy instead of anonymising individual fields. This method is
     # incompatible with the fields strategy.

--- a/lib/anony/selectors.rb
+++ b/lib/anony/selectors.rb
@@ -7,13 +7,20 @@ module Anony
     def initialize(model_class, &block)
       @model_class = model_class
       @selectors = {}
+      @associations = nil
       instance_exec(&block) if block
     end
 
-    attr_reader :selectors
+    attr_reader :selectors, :associations
 
     def for_subject(subject, &block)
       selectors[subject] = block
+    end
+
+    def for_associations(*associations)
+      raise ArgumentError, "One or more associations required" unless associations.any?
+
+      @associations = associations
     end
 
     def select(subject, subject_id)

--- a/lib/anony/version.rb
+++ b/lib/anony/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Anony
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/spec/anony/helpers/database.rb
+++ b/spec/anony/helpers/database.rb
@@ -21,6 +21,14 @@ ActiveRecord::Schema.define do
     t.datetime :anonymised_at
   end
 
+  create_table :employee_pets do |t|
+    t.string :first_name, null: false
+    t.string :last_name
+    t.string :animal, null: false
+    t.datetime :anonymised_at
+    t.belongs_to :employee
+  end
+
   create_table :only_ids
 
   create_table :a_fields, id: false do |t|


### PR DESCRIPTION
It is rare that records need to be anonymised in isolation, and this makes it easy to configure the associations on a model which should be anonymised at the same time. This should greatly simplify finding and anonymising all records for a given subject across large, complex database structures