### PR TITLE
Update cops to use Base rather than Cop as base class.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,7 @@ Gemspec/RequiredRubyVersion:
 
 RSpec/MultipleExpectations:
   Enabled: false
+
+RSpec/ExampleLength:
+  Max: 15
+

--- a/lib/anony/cops/define_deletion_strategy.rb
+++ b/lib/anony/cops/define_deletion_strategy.rb
@@ -22,7 +22,7 @@ module RuboCop
       #
       # @example Bad
       #   class MyNewThing < ApplicationRecord; end
-      class DefineDeletionStrategy < Cop
+      class DefineDeletionStrategy < Base
         MSG = "Define .anonymise for %<model>s, see https://github.com/gocardless/" \
               "anony/blob/#{Anony::VERSION}/README.md for details".freeze
 

--- a/lib/anony/version.rb
+++ b/lib/anony/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Anony
-  VERSION = "1.3.1"
+  VERSION = "1.4.0"
 end

--- a/spec/anony/activerecord_spec.rb
+++ b/spec/anony/activerecord_spec.rb
@@ -31,7 +31,6 @@ RSpec.context "ActiveRecord integration" do
 
   it_behaves_like "overwritten anonymisable model"
 
-  # rubocop:disable RSpec/ExampleLength
   it "applies the correct changes to each column" do
     expect { instance.anonymise! }.
       to change(instance, :first_name).to(/[\h-]{36}/).
@@ -41,7 +40,6 @@ RSpec.context "ActiveRecord integration" do
       and change(instance, :company_name).to("anonymised-Microsoft").
       and change(instance, :onboarded_at).to be_within(1).of(Time.now)
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it "populates the result fields hash with only anonymised fields" do
     result = instance.anonymise!

--- a/spec/rubocop/cop/lint/define_deletion_strategy_spec.rb
+++ b/spec/rubocop/cop/lint/define_deletion_strategy_spec.rb
@@ -1,35 +1,33 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "rubocop"
-require "rubocop/rspec/cop_helper"
+require "rubocop/rspec/support"
+require "spec_helper"
 require "anony/cops/define_deletion_strategy"
 
-RSpec.describe RuboCop::Cop::Lint::DefineDeletionStrategy do
-  include CopHelper
-
-  let(:cop) { described_class.new(config) }
+RSpec.describe RuboCop::Cop::Lint::DefineDeletionStrategy, :config do
+  include RuboCop::RSpec::ExpectOffense
 
   let(:config) { RuboCop::Config.new(described_class.cop_name => cop_config) }
-
   let(:cop_config) { {} }
 
-  before { inspect_source(source) }
+  let(:error_msg) do
+    "Define .anonymise for %s, see https://github.com/gocardless/anony/" \
+      "blob/#{Anony::VERSION}/README.md for details"
+  end
 
   context "when it isn't a model" do
-    let(:source) do
-      <<~RUBY
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
         class Service
         end
       RUBY
     end
-
-    it { expect(cop.offenses).to be_empty }
   end
 
   context "when it doesn't directly subclass ApplicationRecord" do
-    let(:source) do
-      <<~RUBY
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
         module Foo
           class ApplicationRecord; end
         end
@@ -37,13 +35,11 @@ RSpec.describe RuboCop::Cop::Lint::DefineDeletionStrategy do
         class Service < Foo::ApplicationRecord; end
       RUBY
     end
-
-    it { expect(cop.offenses).to be_empty }
   end
 
   context "when a model already defines anonymisation rules" do
-    let(:source) do
-      <<~RUBY
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
         class Employee < ApplicationRecord
           anonymise do
             destroy
@@ -51,58 +47,40 @@ RSpec.describe RuboCop::Cop::Lint::DefineDeletionStrategy do
         end
       RUBY
     end
-
-    it { expect(cop.offenses).to be_empty }
   end
 
   context "when a model does not define anonymisation rules" do
     subject(:offenses) { cop.offenses }
 
-    shared_examples_for "an offense" do
-      it { expect(offenses.count).to eq(1) }
-
-      it "has the correct name" do
-        expect(offenses.first.cop_name).to eq(cop.name)
-      end
-
-      it "has the correct message" do
-        expect(offenses.first.message).
-          to eq("Define .anonymise for Employee, see https://github.com/gocardless/anony/" \
-                "blob/#{Anony::VERSION}/README.md for details")
-      end
-    end
-
-    let(:source) do
-      <<~RUBY
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
         class Employee < ApplicationRecord
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{error_msg % 'Employee'}
         end
       RUBY
     end
 
-    it_behaves_like "an offense"
-
-    context "with a custom model superclasss" do
+    context "with a custom model superclass" do
       let(:cop_config) { { "ModelSuperclass" => "Acme::Record" } }
 
-      let(:source) do
-        <<~RUBY
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
           class Employee < Acme::Record
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{error_msg % 'Employee'}
           end
         RUBY
       end
-
-      it_behaves_like "an offense"
     end
   end
 
-  context "when it uses multiple super classes" do
+  context "when it uses multiple superclasses" do
     subject(:offenses) { cop.offenses }
 
-    let(:cop_config) { { "ModelSuperclass" => ["Acme::Record", "Another::Record"] } }
+    let(:cop_config) { { "ModelSuperclass" => %w[Acme::Record Another::Record] } }
 
     context "when models defines anonymisation rules" do
-      let(:source) do
-        <<~RUBY
+      it "doesn't register an offense" do
+        expect_no_offenses(<<~RUBY)
           class Employee < Acme::Record
             anonymise do
               destroy
@@ -116,25 +94,19 @@ RSpec.describe RuboCop::Cop::Lint::DefineDeletionStrategy do
           end
         RUBY
       end
-
-      it { expect(cop.offenses).to be_empty }
     end
 
     context "when models are missing anonymisation rules" do
-      let(:source) do
-        <<~RUBY
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
           class Employee < Another::Record
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{error_msg % 'Employee'}
           end
 
           class Boss < Another::Record
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{error_msg % 'Boss'}
           end
         RUBY
-      end
-
-      it { expect(offenses.count).to eq(2) }
-
-      it "has the correct name" do
-        expect(offenses.first.cop_name).to eq(cop.name)
       end
     end
   end


### PR DESCRIPTION
In Rubocop 1.65, using deprecated APIs will now display a warning per rubocop/rubocop#13032. This updates the cops to use the correct base class.