### PR TITLE
Drop support for EOL Rails 6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: [3.1, 3.2, 3.3]
-        rails-version: [6.1, 7.0, 7.1, 7.2]
+        rails-version: [7.0, 7.1, 7.2]
     runs-on: ubuntu-latest
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.5.0
 
-- Drop support for EOL Ruby 3.0
+- Drop support for EOL Ruby 3.0 (EOL since April 1st 2024)
+- Drop support for EOL Rails 6.1 (EOL since October 1st 2024)
 - Add support for Rails 7.2
 - Fix Dependabot updates
 

--- a/anony.gemspec
+++ b/anony.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
     spec.add_dependency "activerecord", "~> #{ENV['RAILS_VERSION']}"
     spec.add_dependency "activesupport", "~> #{ENV['RAILS_VERSION']}"
   else
-    spec.add_dependency "activerecord", ">= 6.1", "< 8"
-    spec.add_dependency "activesupport", ">= 6.1", "< 8"
+    spec.add_dependency "activerecord", ">= 7.0", "< 8"
+    spec.add_dependency "activesupport", ">= 7.0", "< 8"
   end
   spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
This is now EOL as well, since October 1st 2024
https://rubyonrails.org/maintenance