### PR TITLE
Fix NoMethodError when calling selector methods w/o anony config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Drop support for EOL Rails 6.1 (EOL since October 1st 2024)
 - Add support for Rails 7.2
 - Fix Dependabot updates
-- Fix `NoMethodError` when calling `selector_for?` on a model class without an `anonymise` config block
+- Fix `NoMethodError` when calling `selector_for?` or `anonymise_for!` on a model class without an `anonymise` config block
 
 # v1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Drop support for EOL Rails 6.1 (EOL since October 1st 2024)
 - Add support for Rails 7.2
 - Fix Dependabot updates
+- Fix `NoMethodError` when calling `selector_for?` on a model class without an `anonymise` config block
 
 # v1.4.0
 

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -76,6 +76,8 @@ module Anony
       # @example
       #   Manager.selector_for?(:user_id)
       def selector_for?(subject)
+        return false if anonymise_config.nil?
+
         anonymise_config.selector_for?(subject)
       end
 

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -58,6 +58,10 @@ module Anony
       # Finds the records that relate to a particular subject and runs anonymise on
       # each of them. If a selector is not defined it will raise an exception.
       def anonymise_for!(subject, subject_id)
+        unless anonymise_config
+          raise ArgumentError, "#{name} does not have an Anony configuration"
+        end
+
         records = anonymise_config.
           select(subject, subject_id)
         records.map do |record|

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -253,17 +253,43 @@ RSpec.describe Anony::Anonymisable do
   end
 
   context "no anonymise block" do
-    describe "#valid_anonymisation?" do
-      let(:klass) do
-        Class.new(ActiveRecord::Base) do
-          include Anony::Anonymisable
+    let(:klass) do
+      Class.new(ActiveRecord::Base) do
+        include Anony::Anonymisable
 
-          self.table_name = :employees
+        def self.name
+          "Employee"
         end
-      end
 
+        self.table_name = :employees
+      end
+    end
+
+    describe "#valid_anonymisation?" do
       it "fails" do
         expect(klass).to_not be_valid_anonymisation
+      end
+    end
+
+    describe "#selector_for?" do
+      it "does not throw an exception" do
+        expect { klass.selector_for?(:foo) }.to_not raise_error
+      end
+
+      it "returns false" do
+        expect(klass.selector_for?(:foo)).to be false
+      end
+    end
+
+    describe "#anonymise_for!" do
+      let(:model) do
+        klass.create!(first_name: "abc", last_name: "foo", company_name: "alpha")
+      end
+
+      it "throws an exception" do
+        expect { klass.anonymise_for!(:first_name, "abc") }.to raise_error(
+          ArgumentError, "Employee does not have an Anony configuration"
+        )
       end
     end
   end

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -221,20 +221,33 @@ RSpec.describe Anony::Anonymisable do
 
   context "without configuring Anony at all" do
     let(:klass) do
-      MyUnicornModel = Class.new(ActiveRecord::Base) do
+      Class.new(ActiveRecord::Base) do
         include Anony::Anonymisable
 
         self.table_name = :only_ids
       end
     end
 
-    let(:model) { klass.new }
-
     describe "#anonymise!" do
+      let(:model) do
+        MyUnicornModel = klass
+        MyUnicornModel.new
+      end
+
       it "throws an exception" do
         expect { model.anonymise! }.to raise_error(
           ArgumentError, "MyUnicornModel does not have an Anony configuration"
         )
+      end
+    end
+
+    describe "#selector_for?" do
+      it "does not throw an exception" do
+        expect { klass.selector_for?(:foo) }.to_not raise_error
+      end
+
+      it "returns false" do
+        expect(klass.selector_for?(:foo)).to be false
       end
     end
   end


### PR DESCRIPTION
When calling `selector_for?` or `anonymise_for!` on a model with no `anonymise` block, instead of throwing a `NoMethodError` due to the anonymisation config being `nil` we now do the following:

* Return `false` when calling `selector_for?`, same as if calling `valid_anonymisation?`
* Raise `ArgumentError` when calling `anonymise_for!`, same as if calling `anonymise!`