### PR TITLE
Add `ignore` strategy that skips anonymisation of a model

### DIFF
--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -85,18 +85,6 @@ module Anony
         anonymise_config.selector_for?(subject)
       end
 
-      # Checks if a model uses a strategy that requires anonymisation. Returns false if the strategy
-      # is ignore, or true for all other strategies
-      # This is useful for checking to see whether a model needs to be anonymised or not.
-      # @return [Boolean]
-      # @example
-      #   Manager.requires_anonymisation?
-      def requires_anonymisation?
-        return false unless @anonymise_config
-
-        !@anonymise_config.instance_variable_get(:@strategy).is_a? Strategies::Ignore
-      end
-
       attr_reader :anonymise_config
     end
 

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -85,6 +85,18 @@ module Anony
         anonymise_config.selector_for?(subject)
       end
 
+      # Checks if a model uses a strategy that requires anonymisation. Returns false if the strategy
+      # is ignore, or true for all other strategies
+      # This is useful for checking to see whether a model needs to be anonymised or not.
+      # @return [Boolean]
+      # @example
+      #   Manager.requires_anonymisation?
+      def requires_anonymisation?
+        return false unless @anonymise_config
+
+        !@anonymise_config.instance_variable_get(:@strategy).is_a? Strategies::Ignore
+      end
+
       attr_reader :anonymise_config
     end
 

--- a/lib/anony/model_config.rb
+++ b/lib/anony/model_config.rb
@@ -3,6 +3,7 @@
 require "active_support/core_ext/module/delegation"
 
 require_relative "strategies/destroy"
+require_relative "strategies/ignore"
 require_relative "strategies/overwrite"
 require_relative "selectors"
 
@@ -50,7 +51,7 @@ module Anony
     delegate :select, to: :@selectors_config
 
     # Use the deletion strategy instead of anonymising individual fields. This method is
-    # incompatible with the fields strategy.
+    # incompatible with the overwrite strategy.
     #
     # This method takes no arguments or blocks.
     #
@@ -65,6 +66,24 @@ module Anony
       end
 
       @strategy = Strategies::Destroy.new
+    end
+
+    # Use the ignore strategy instead of anonymising anything. This method is
+    # incompatible with the overwrite and destroy strategies.
+    #
+    # This method takes no arguments or blocks.
+    #
+    # @example
+    #   anonymise do
+    #     ignore
+    #   end
+    def ignore
+      raise ArgumentError, ":ignore takes no block" if block_given?
+      unless @strategy.is_a?(UndefinedStrategy)
+        raise ArgumentError, "Cannot specify :ignore when another strategy already defined"
+      end
+
+      @strategy = Strategies::Ignore.new
     end
 
     # Use the overwrite strategy to configure rules for individual fields. This method is

--- a/lib/anony/strategies/ignore.rb
+++ b/lib/anony/strategies/ignore.rb
@@ -2,16 +2,16 @@
 
 module Anony
   module Strategies
-    # The interface for configuring a destroy strategy. This strategy is not compatible
+    # The interface for configuring an ignore strategy. This strategy is not compatible
     # with the following strategies:
-    # * Anony::Strategies::Ignore
+    # * Anony::Strategies::Destroy
     # * Anony::Strategies::Overwrite
     #
     # @example
     #   anonymise do
-    #     destroy
+    #     ignore
     #   end
-    class Destroy
+    class Ignore
       # Whether the strategy is valid. This strategy takes no configuration, so #valid?
       # always returns true
       #
@@ -28,13 +28,11 @@ module Anony
         true
       end
 
-      # Apply the Destroy strategy to the model instance. In this case, it calls
-      # `#destroy!`.
+      # Apply the Ignore strategy to the model instance. In this case, it is a noop
       #
       # @param [ActiveRecord::Base] instance An instance of the model
       def apply(instance)
-        instance.destroy!
-        Result.destroyed(instance)
+        Result.skipped(instance)
       end
     end
   end

--- a/lib/anony/strategies/overwrite.rb
+++ b/lib/anony/strategies/overwrite.rb
@@ -4,8 +4,12 @@ require_relative "../field_level_strategies"
 
 module Anony
   module Strategies
-    # The interface for configuring a field-level strategy. All of the methods here are
-    # made available inside the `overwrite { ... }` block:
+    # The interface for configuring a field-level strategy. This strategy is not compatible
+    # with the following strategies:
+    # * Anony::Strategies::Destroy
+    # * Anony::Strategies::Ignore
+    #
+    # All of the methods here are made available inside the `overwrite { ... }` block:
     #
     # @example
     #   anonymise do

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -112,12 +112,6 @@ RSpec.describe Anony::Anonymisable do
         end
       end
     end
-
-    describe "#requires_anonymisation?" do
-      it "requires anonymisation" do
-        expect(klass.requires_anonymisation?).to be true
-      end
-    end
   end
 
   context "destroy on anonymise" do
@@ -150,12 +144,6 @@ RSpec.describe Anony::Anonymisable do
     describe "#valid_anonymisation?" do
       it "is valid" do
         expect(klass).to be_valid_anonymisation
-      end
-    end
-
-    describe "#requires_anonymisation?" do
-      it "requires anonymisation" do
-        expect(klass.requires_anonymisation?).to be true
       end
     end
   end
@@ -191,12 +179,6 @@ RSpec.describe Anony::Anonymisable do
     describe "#valid_anonymisation?" do
       it "is valid" do
         expect(klass).to be_valid_anonymisation
-      end
-    end
-
-    describe "#requires_anonymisation?" do
-      it "does not require anonymisation" do
-        expect(klass.requires_anonymisation?).to be false
       end
     end
   end

--- a/spec/anony/anonymisable_spec.rb
+++ b/spec/anony/anonymisable_spec.rb
@@ -112,6 +112,12 @@ RSpec.describe Anony::Anonymisable do
         end
       end
     end
+
+    describe "#requires_anonymisation?" do
+      it "requires anonymisation" do
+        expect(klass.requires_anonymisation?).to be true
+      end
+    end
   end
 
   context "destroy on anonymise" do
@@ -135,11 +141,62 @@ RSpec.describe Anony::Anonymisable do
 
         model.anonymise!
       end
+
+      it "returns a destroyed result" do
+        expect(model.anonymise!.destroyed?).to be true
+      end
     end
 
     describe "#valid_anonymisation?" do
       it "is valid" do
         expect(klass).to be_valid_anonymisation
+      end
+    end
+
+    describe "#requires_anonymisation?" do
+      it "requires anonymisation" do
+        expect(klass.requires_anonymisation?).to be true
+      end
+    end
+  end
+
+  context "ignore anonymise" do
+    let(:klass) do
+      Class.new(ActiveRecord::Base) do
+        include Anony::Anonymisable
+
+        self.table_name = :employees
+
+        anonymise do
+          ignore
+        end
+      end
+    end
+
+    let(:model) { klass.new }
+
+    describe "#anonymise!" do
+      it "skips the model" do
+        expect(model).to_not receive(:destroy!)
+        expect(model).to_not receive(:write_attribute)
+
+        model.anonymise!
+      end
+
+      it "returns a skipped result" do
+        expect(model.anonymise!.skipped?).to be true
+      end
+    end
+
+    describe "#valid_anonymisation?" do
+      it "is valid" do
+        expect(klass).to be_valid_anonymisation
+      end
+    end
+
+    describe "#requires_anonymisation?" do
+      it "does not require anonymisation" do
+        expect(klass.requires_anonymisation?).to be false
       end
     end
   end


### PR DESCRIPTION
It is not uncommon for models to contain no personal data that needs anonymising and this is often worked around by listing every field in the model under an `ignore` field strategy as part of an `overwrite` strategy.

To simplify config for these situations, add an `ignore` strategy that causes the model to be skipped when anonymising.

Also add a helper method `requires_anonymisation?` to make it easy to tell whether or not a model needs anonymising, which can save time and DB queries when finding records to be anonymised