### PR TITLE
Add config option to prevent validating models before anonymisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,28 @@ Anony::Config.ignore_fields(:id, :created_at, :updated_at)
 By default, `Config.ignore_fields` is an empty array and all fields are considered
 anonymisable.
 
+### Preventing model validation before anonymisation
+
+There are cases where models may contain data that is not valid according to the validations defined on the model, and
+the default behaviour of Anony is to validate the model before anonymisation.
+
+If it is necessary to be able to anonymise models even if they contain invalid data, Anony can be configured to skip this
+validation, in which case the validations will only be run when using strategies that modify the model data, and will run
+after anonymisation when the model is saved.
+
+To configure this behaviour, you can set the following configuration option in an initializer:
+
+```ruby
+# config/initializers/anony.rb
+
+Anony::Config.validate_before_anonymisation = false
+```
+
+> Note: If you set this configuration option to `false`, be aware that a model that is invalid before anonymisation and continues
+  to be invalid after anonymisation may have new validation failures caused by the anonymisation if a strategy is incorrectly
+  defined for the model. It is recommended that you perform the anonymisation in a database transaction and roll it back if there
+  are validation errors after anonymisation.
+
 ## Testing
 
 This library ships with a set of useful RSpec examples for your specs. Just require them

--- a/lib/anony/anonymisable.rb
+++ b/lib/anony/anonymisable.rb
@@ -99,7 +99,7 @@ module Anony
         raise ArgumentError, "#{self.class.name} does not have an Anony configuration"
       end
 
-      self.class.anonymise_config.validate!
+      self.class.anonymise_config.validate! if Config.validate_before_anonymisation
       self.class.anonymise_config.apply(self)
     rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotDestroyed => e
       Result.failed(e, self)

--- a/lib/anony/config.rb
+++ b/lib/anony/config.rb
@@ -12,7 +12,7 @@ module Anony
   #
   #   Anony::Config.ignore_fields(:id)
   module Config
-    mattr_accessor :ignores
+    mattr_accessor :ignores, :validate_before_anonymisation
 
     # @!visibility private
     def self.ignore?(field)
@@ -38,5 +38,14 @@ module Anony
     end
 
     self.ignores = []
+
+    # Config option to change behaviour so that validations on models being anonymised
+    # are not run before anonymisation has been performed. This means that if an invalid model
+    # would become valid after anonymisation, it will not raise an error when being anonymised.
+    #
+    # Validations are still run for the overwrite strategy when the changes to the model are saved
+    #
+    # By default this is set to true, to maintain existing behaviour
+    self.validate_before_anonymisation = true
   end
 end


### PR DESCRIPTION
Allows anonymisation of models that contain invalid data, as there are times when this is necessary. This behaviour is not configured by default, but can be set via a global configuration option in an initializer